### PR TITLE
Numba Compilation Error Fix - hasattr() Issue

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,24 +25,22 @@ jobs:
         python-version: [3.12]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
       - name: Install Linux libraries
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
             libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 pkg-config libhdf5-103 libhdf5-dev \
+            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 pkg-config \
             libegl1
+          
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
@@ -56,9 +54,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel setuptools tox tox-gh-actions
-          pip install pydrive2 py # Added py due to pytest tox issues requiring py module.
-
+          pip install tox tox-gh-actions
+          
       - name: Test with tox
         run: tox
         env:
@@ -66,19 +63,26 @@ jobs:
       # ONLY UNCOMMENT SECTION BELOW FOR DEBUGGING PURPOSES: allows one to ssh into host machine. 
       # Follow instructions in  https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account 
       # to add your ssh keys.
-#      - name: Job failed. Activating debugging mode via up-term.
-#        if: ${{ failure() }}
-#        uses: lhotari/action-upterm@v1
-#        with:
-#           ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-#            limit-access-to-actor: true
-#           ## limits ssh access and adds the ssh public keys of the listed GitHub users
-#            limit-access-to-users: chriski777, carsen-stringera
-            
+      # - name: Job failed. Activating debugging mode via up-term.
+      #   if: ${{ failure() }}
+      #   # As of Dec. 2024, The following action does NOT work for MACOS (https://github.com/lhotari/action-upterm/issues/24)
+      #   # uses: lhotari/action-upterm@v1
+      #   # with:
+      #   #   ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+      #   #    limit-access-to-actor: true
+      #   #   ## limits ssh access and adds the ssh public keys of the listed GitHub users
+      #   #    limit-access-to-users: chriski777 #, carsen-stringera
+        
+      #   # As of Dec. 2024, use the following for debugging the GitHub Action runners for MacOS
+      #   uses: owenthereal/action-upterm@v1
+      #   with:
+      #      limit-access-to-actor: true
+      #      limit-access-to-users: chriski777   
+           
       - name: Coverage
         # Only run coverage once
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/suite2p/detection/anatomical.py
+++ b/suite2p/detection/anatomical.py
@@ -136,8 +136,12 @@ def roi_detect(ops, mproj, mov, diameter=None, cellprob_threshold=0.0, flow_thre
     _, masks = np.unique(np.int32(masks), return_inverse=True)
     masks = masks.reshape(shape)
     centers, mask_diams = mask_centers(masks)
-    print(">>>> %d masks detected, median diameter = %0.2f " %
-          (masks.max(), median_diam))
+    if median_diam is not None:
+        print(">>>> %d masks detected, median diameter = %0.2f " %
+              (masks.max(), median_diam))
+    else:
+        print(">>>> %d masks detected, median diameter = None (estimation failed)" %
+              masks.max())
     return masks, centers, median_diam, mask_diams.astype(np.int32)
 
 
@@ -262,7 +266,7 @@ def estimate_diameter_from_activity(ops, mov):
     ops_copy["anatomical_only"] = 0
     try:
         # Use the full movie for activity-based detection
-        stat = select_rois(ops_copy, mov, sparse_mode=ops_copy.get("sparse_mode", True))
+        stat = select_rois(ops_copy, mov)
         if len(stat) > 0:
             # Estimate diameter for each ROI
             diams = []

--- a/suite2p/detection/anatomical.py
+++ b/suite2p/detection/anatomical.py
@@ -48,14 +48,16 @@ def patch_detect(patches, diam):
     tic = time.time()
     for j in np.arange(0, npatches, batch_size):
         # Maintain compatibility with both Cellpose 3 and 4
-        if hasattr(model, 'net'):
-            # Cellpose 4
+        # Use try-except instead of hasattr for Numba compatibility
+        try:
+            # Try Cellpose 4 first
             y = model.net(imgs[j:j + batch_size])[0]
-        elif hasattr(model, 'cp') and hasattr(model.cp, 'network'):
-            # Cellpose 3
-            y = model.cp.network(imgs[j:j + batch_size])[0]
-        else:
-            raise AttributeError("Could not find network attribute in Cellpose model - unsupported Cellpose version")
+        except AttributeError:
+            try:
+                # Try Cellpose 3
+                y = model.cp.network(imgs[j:j + batch_size])[0]
+            except AttributeError:
+                raise AttributeError("Could not find network attribute in Cellpose model - unsupported Cellpose version")
         
         y = y[:, :, ysub[0]:ysub[-1] + 1, xsub[0]:xsub[-1] + 1]
         y = y.asnumpy()

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39}-{linux,macos,windows}
+envlist = py{312}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.8: py38
-    #3.9: py39
+    3.12: py312
     
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
[`photon-mosaic` tests fail](https://github.com/neuroinformatics-unit/photon-mosaic/pull/23):
```
Traceback (most recent call last):
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typeinfer.py", line 160, in propagate
E             constraint(typeinfer)
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typeinfer.py", line 566, in __call__
E             self.resolve(typeinfer, typevars, fnty)
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typeinfer.py", line 589, in resolve
E             sig = typeinfer.resolve_call(fnty, pos_args, kw_args)
E                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typeinfer.py", line 1560, in resolve_call
E             return self.context.resolve_function_type(fnty, pos_args, kw_args)
E                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typing/context.py", line 212, in resolve_function_type
E             raise last_exception
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typing/context.py", line 195, in resolve_function_type
E             res = self._resolve_user_function_type(func, args, kws)
E                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/typing/context.py", line 247, in _resolve_user_function_type
E             return func.get_call_type(self, args, kws)
E                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/types/functions.py", line 329, in get_call_type
E             failures.raise_error()
E           File "/Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/core/types/functions.py", line 227, in raise_error
E             raise errors.TypingError(self.format())
E         numba.core.errors.TypingError: No implementation of function Function(<intrinsic resolve_hasattr>) found for signature:
E          
E          >>> resolve_hasattr(int64, unicode_type)
E          
E         There are 2 candidate implementations:
E          - Of which 2 did not match due to:
E          Intrinsic in function 'resolve_hasattr': File: numba/cpython/old_builtins.py: Line 970.
E            With argument(s): '(int64, unicode_type)':
E           Rejected as the implementation raised a specific error:
E             RequireLiteralValue: argument 'name' must be a literal string
E           raised from /Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/cpython/old_builtins.py:973
E         
E         During: resolving callee type: Function(<intrinsic resolve_hasattr>)
E         During: typing of call at /Users/lauraporta/miniforge3/envs/new-cimat/lib/python3.12/site-packages/numba/cpython/old_builtins.py (999)
```

I think the reason is that when photon-mosaic calls suite2p functions from within a Numba-compiled function, Numba tries to compile the entire call chain, including these `hasattr()` calls. Even though the strings 'net', 'cp', and 'network' are literals, Numba sometimes has trouble with `hasattr()` on complex objects.

**What does this PR do?**
Replaced `hasattr()` calls with try-except blocks

## How has this PR been tested?
Tested locally with pytest on `photon-mosaic`